### PR TITLE
Allow non-debug execution

### DIFF
--- a/gym_duckietown/graphics.py
+++ b/gym_duckietown/graphics.py
@@ -99,8 +99,9 @@ def create_frame_buffers(width, height, num_samples):
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depth_rb);
 
     # Sanity check
-    res = glCheckFramebufferStatus(GL_FRAMEBUFFER)
-    assert res == GL_FRAMEBUFFER_COMPLETE
+    if pyglet.options['debug_gl']:
+      res = glCheckFramebufferStatus(GL_FRAMEBUFFER)
+      assert res == GL_FRAMEBUFFER_COMPLETE
 
     # Create the frame buffer used to resolve the final render
     final_fbo = GLuint(0)
@@ -129,8 +130,9 @@ def create_frame_buffers(width, height, num_samples):
         fbTex,
         0
     )
-    res = glCheckFramebufferStatus(GL_FRAMEBUFFER)
-    assert res == GL_FRAMEBUFFER_COMPLETE
+    if pyglet.options['debug_gl']:
+      res = glCheckFramebufferStatus(GL_FRAMEBUFFER)
+      assert res == GL_FRAMEBUFFER_COMPLETE
 
     # Enable depth testing
     glEnable(GL_DEPTH_TEST)


### PR DESCRIPTION
I added some checks which allow non-debug execution, which gives me 3x speedup. So I think this might be worth documenting.

Regular debug mode:
```
$ python benchmark.py
...
load time: 540 ms
reset time: 6.1 ms
frame time: 4.8 ms
frame rate: 206.5 FPS
```

Debug disabled (can also be done setting env variable PYGLET_DEBUG_GL to False):
```
$ python -O benchmark.py
load time: 486 ms
reset time: 2.8 ms
frame time: 1.6 ms
frame rate: 636.5 FPS
```