### PR TITLE
Undefined name: np.array(), instead of numpy.array()

### DIFF
--- a/gym_duckietown/wrappers.py
+++ b/gym_duckietown/wrappers.py
@@ -25,8 +25,8 @@ class HeadingWrapper(gym.Wrapper):
         #print(action)
 
         # Compute the motor velocities
-        lVel = numpy.array([0.4, 0.5])
-        rVel = numpy.array([0.5, 0.4])
+        lVel = np.array([0.4, 0.5])
+        rVel = np.array([0.5, 0.4])
 
         x = (action + 1) / 2
         #print(x)


### PR DESCRIPTION
These changes align with line 2 which does __import numpy as np__.

flake8 testing of https://github.com/duckietown/gym-duckietown on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./gym_duckietown/wrappers.py:28:16: F821 undefined name 'numpy'
        lVel = numpy.array([0.4, 0.5])
               ^
./gym_duckietown/wrappers.py:29:16: F821 undefined name 'numpy'
        rVel = numpy.array([0.5, 0.4])
               ^
./pytorch_rl/vec_env/__init__.py:62:9: F821 undefined name 'logger'
        logger.warn('Render not defined for %s'%self)
        ^
3     F821 undefined name 'numpy'
3
```