### PR TITLE
Graphics - Rotate Point Fix

### DIFF
--- a/gym_duckietown/graphics.py
+++ b/gym_duckietown/graphics.py
@@ -197,10 +197,10 @@ def rotate_point(px, py, cx, cy, theta):
     dx = px - cx
     dy = py - cy
 
-    dx = dx * math.cos(theta) - dy * math.sin(theta)
-    dy = dy * math.cos(theta) + dx * math.sin(theta)
+    new_x = dx * math.cos(theta) - dy * math.sin(theta)
+    new_x = dy * math.cos(theta) + dx * math.sin(theta)
 
-    return cx + dx, cy + dy
+    return cx + new_x, cy + new_y
 
 def gen_rot_matrix(axis, angle):
     """


### PR DESCRIPTION
Small bug in the rotate_point function, leading to rotations like this:

(Black: Points to Rotate, Blue Original Code, Green Fixed)

![image](https://user-images.githubusercontent.com/10503729/41795954-99da9cca-7632-11e8-9b67-345ff2ae86e4.png)
