### PR TITLE
Dynamic obstacles

### DIFF
--- a/gym_duckietown/collision.py
+++ b/gym_duckietown/collision.py
@@ -177,3 +177,12 @@ def calculate_safety_radius(mesh, scale):
     """
     x, _, z = np.max([abs(mesh.min_coords), abs(mesh.max_coords)], axis=0)
     return np.linalg.norm([x, z]) * scale 
+
+def heading_vec(angle):
+    """
+    Vector pointing in the direction the agent is looking
+    """
+
+    x = math.cos(angle)
+    z = -math.sin(angle)
+    return np.array([x, 0, z])

--- a/gym_duckietown/envs/simplesim_env.py
+++ b/gym_duckietown/envs/simplesim_env.py
@@ -512,7 +512,7 @@ class SimpleSimEnv(gym.Env):
                     dyn_idx += 1
 
                     self.pedestrians.append(pedestrian)
-                    self.pedestrian_active.append(True)
+                    self.pedestrian_active.append(False)
 
                     # Randomize velocity and wait time
                     if self.domain_rand:

--- a/gym_duckietown/maps/loop_obstacles.yaml
+++ b/gym_duckietown/maps/loop_obstacles.yaml
@@ -42,3 +42,10 @@ objects:
   pos: [0.9, 3]
   rotate: 100
   height: 0.08
+
+- kind: duckie
+  pos: [3.0, 6.0]
+  rotate: 90
+  height: 0.08
+  static: False
+  pedestrian: True

--- a/gym_duckietown/maps/loop_obstacles_pedestrians.yaml
+++ b/gym_duckietown/maps/loop_obstacles_pedestrians.yaml
@@ -47,4 +47,19 @@ objects:
   pos: [3.0, 6.0]
   rotate: 90
   height: 0.08
-  static: True
+  static: False
+  pedestrian: True
+
+- kind: duckie
+  pos: [4.0, 6.0]
+  rotate: 90
+  height: 0.08
+  static: False
+  pedestrian: True
+
+- kind: duckie
+  pos: [3.5, 6.0]
+  rotate: 90
+  height: 0.08
+  static: False
+  pedestrian: True


### PR DESCRIPTION
This PR deals with adding dynamic obstacles - in this case, only pedestrian duckies that walk across the road, which can be specified by adding:

```
static: False
pedestrian: True 
```

To the object's description in the YAML File.

In domain rand. mode, they walk across the same specified distance (`ROAD_TILE_WIDTH`) at randomized speeds, and have randomized time intervals between their walks.

I tried to vectorize as much as possible (see `_update_dynamic_obs()` and `update_pedestrians()`) and I  tried to run as many tests as possible, but we will need to play around with it to get especially the speed that they should walk across correct. I believe my current setting is a bit too high.

Tested w. draw-bbox mode + domain-rand mode, as well as different combinations of maps. To test, I've added a small map called `loop_obstacles_pedestrians`.