### PR TITLE
Free camera mode

### DIFF
--- a/free_camera.py
+++ b/free_camera.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+"""
+This script allows you to manually control the simulator or Duckiebot
+using the keyboard arrows.
+"""
+
+import sys
+import argparse
+from pyglet import app, clock
+from pyglet.window import key
+import gym
+import gym_duckietown
+from gym_duckietown.envs import DuckietownEnv
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--env-name', default=None)
+parser.add_argument('--map-name', default='udem1')
+parser.add_argument('--draw-curve', action='store_true', help='draw the lane following curve')
+parser.add_argument('--draw-bbox', action='store_true', help='draw collision detection bounding boxes')
+parser.add_argument('--domain-rand', action='store_true', help='enable domain randomization')
+parser.add_argument('--frame-skip', default=1, type=int, help='number of frames to skip')
+args = parser.parse_args()
+
+if args.env_name is None:
+    env = DuckietownEnv(
+        map_name=args.map_name,
+        draw_curve=args.draw_curve,
+        draw_bbox=args.draw_bbox,
+        domain_rand=args.domain_rand,
+        frame_skip=args.frame_skip
+    )
+else:
+    env = gym.make(args.env_name)
+
+env.reset()
+env.render()
+
+
+@env.unwrapped.window.event
+def on_key_press(symbol, modifiers):
+    """
+    This handler processes keyboard commands that control the simulation
+    """
+
+    if symbol == key.BACKSPACE or symbol == key.SLASH:
+        env.reset()
+        env.render()
+        return
+    elif symbol == key.ESCAPE:
+        env.close()
+        sys.exit(0)
+
+    # Camera movement
+    cam_offset, cam_angle = env.unwrapped.cam_offset, env.unwrapped.cam_angle
+    if symbol == key.W:
+        cam_angle[0] -= 5
+    elif symbol == key.S:
+        cam_angle[0] += 5
+    elif symbol == key.A:
+        cam_angle[1] -= 5
+    elif symbol == key.D:
+        cam_angle[1] += 5
+    elif symbol == key.Q:
+        cam_angle[2] -= 5
+    elif symbol == key.E:
+        cam_angle[2] += 5
+    elif symbol == key.UP:
+        if modifiers:  # Mod+Up for height
+            cam_offset[1] += .1
+        else:
+            cam_offset[0] += .1
+    elif symbol == key.DOWN:
+        if modifiers:  # Mod+Down for height
+            cam_offset[1] -= .1
+        else:
+            cam_offset[0] -= .1
+    elif symbol == key.LEFT:
+        cam_offset[2] -= .1
+    elif symbol == key.RIGHT:
+        cam_offset[2] += .1
+
+
+# Main event loop
+clock.schedule_interval(env.render, 1 / env.unwrapped.frame_rate)
+app.run()
+
+env.close()

--- a/free_camera.py
+++ b/free_camera.py
@@ -81,8 +81,12 @@ def on_key_press(symbol, modifiers):
         cam_offset[2] += .1
 
 
+def update(dt):
+    env.render('free_cam')
+
+
 # Main event loop
-clock.schedule_interval(env.render, 1 / env.unwrapped.frame_rate)
+clock.schedule_interval(update, 1 / env.unwrapped.frame_rate)
 app.run()
 
 env.close()

--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -275,8 +275,8 @@ class Simulator(gym.Env):
         # Distance bewteen camera and ground
         self.cam_height = self._perturb(CAMERA_FLOOR_DIST, 0.08)
 
-        # Angle at which the camera is pitched downwards
-        self.cam_angle = self._perturb(CAMERA_ANGLE, 0.2)
+        # Angle at which the camera is rotated
+        self.cam_angle = [self._perturb(CAMERA_ANGLE, 0.2), 0, 0]
 
         # Field of view angle of the camera
         self.cam_fov_y = self._perturb(CAMERA_FOV_Y, 0.2)
@@ -991,7 +991,9 @@ class Simulator(gym.Env):
             glRotatef(90, 1, 0, 0)
         else:
             y += self.cam_height
-            glRotatef(self.cam_angle, 1, 0, 0)
+            glRotatef(self.cam_angle[0], 1, 0, 0)
+            glRotatef(self.cam_angle[1], 0, 1, 0)
+            glRotatef(self.cam_angle[2], 0, 0, 1)
             glTranslatef(0, 0, self._perturb(CAMERA_FORWARD_DIST))
 
         gluLookAt(

--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -281,6 +281,9 @@ class Simulator(gym.Env):
         # Field of view angle of the camera
         self.cam_fov_y = self._perturb(CAMERA_FOV_Y, 0.2)
 
+        # Camera offset for use in free camera mode
+        self.cam_offset = [0, 0, 0]
+
         # Create the vertex list for the ground/noise triangles
         # These are distractors, junk on the floor
         numTris = 12
@@ -981,7 +984,7 @@ class Simulator(gym.Env):
         pos = self.cur_pos
         if self.domain_rand:
             pos = pos + self.np_random.uniform(low=-0.005, high=0.005, size=(3,))
-        x, y, z = pos
+        x, y, z = pos + self.cam_offset
         dx, dy, dz = self.get_dir_vec()
         glMatrixMode(GL_MODELVIEW)
         glLoadIdentity()

--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -990,7 +990,7 @@ class Simulator(gym.Env):
             y += 0.8
             glRotatef(90, 1, 0, 0)
         else:
-            y += CAMERA_FLOOR_DIST
+            y += self.cam_height
             glRotatef(self.cam_angle, 1, 0, 0)
             glTranslatef(0, 0, self._perturb(CAMERA_FORWARD_DIST))
 

--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -1186,14 +1186,15 @@ class Simulator(gym.Env):
         )
 
         # Display position/state information
-        x, y, z = self.cur_pos
-        self.text_label.text = "pos: (%.2f, %.2f, %.2f), angle: %d, steps: %d, speed: %.2f m/s" % (
-            x, y, z,
-            int(self.cur_angle * 180 / math.pi),
-            self.step_count,
-            self.speed
-        )
-        self.text_label.draw()
+        if mode != "free_cam":
+            x, y, z = self.cur_pos
+            self.text_label.text = "pos: (%.2f, %.2f, %.2f), angle: %d, steps: %d, speed: %.2f m/s" % (
+                x, y, z,
+                int(self.cur_angle * 180 / math.pi),
+                self.step_count,
+                self.speed
+            )
+            self.text_label.draw()
 
         # Force execution of queued commands
         glFlush()

--- a/joystick_control.py
+++ b/joystick_control.py
@@ -90,7 +90,7 @@ def on_key_press(symbol, modifiers):
         env.reset()
         env.render()
     elif symbol == key.PAGEUP:
-        env.unwrapped.cam_angle = 0
+        env.unwrapped.cam_angle[0] = 0
         env.render()
     elif symbol == key.ESCAPE:
         env.close()

--- a/manual_control.py
+++ b/manual_control.py
@@ -50,7 +50,6 @@ def on_key_press(symbol, modifiers):
         env.render()
     elif symbol == key.PAGEUP:
         env.unwrapped.cam_angle = 0
-        env.render()
     elif symbol == key.ESCAPE:
         env.close()
         sys.exit(0)

--- a/manual_control.py
+++ b/manual_control.py
@@ -49,7 +49,7 @@ def on_key_press(symbol, modifiers):
         env.reset()
         env.render()
     elif symbol == key.PAGEUP:
-        env.unwrapped.cam_angle = 0
+        env.unwrapped.cam_angle[0] = 0
     elif symbol == key.ESCAPE:
         env.close()
         sys.exit(0)


### PR DESCRIPTION
Related to #21 

I took a different approach. Instead of a separate script, it is an flag that can be toggled using *SPACE*. If the camera is in free mode, you can wander around with the arrows and rotate or adjust the pitch with *W*, *A*, *S*, *D*, *E*, *Q*. If you press *SPACE* again, the camera is mounted back to the point of view of the robot, and movement is back to normal.

Since the steps are now updated automatically, I didn't bother to separate the logic.

This PR also includes a fix for the flickering on `PAGEUP` due to the call to `env.render()` and uses the `self.cam_height` variable already in place instead of the constant, so that domain randomization can affect the camera height of the bot.

![aerial_shot](https://user-images.githubusercontent.com/11507066/44064150-a88cd9ae-9f31-11e8-9ece-c89a0e7f7ebd.png)