### PR TITLE
Fixes int conversion for MAX STEPS

### DIFF
--- a/gym_duckietown/launcher.py
+++ b/gym_duckietown/launcher.py
@@ -15,7 +15,7 @@ def main():
     # get parameters from environment (set during docker launch) otherwise take default
     map = os.getenv('DUCKIETOWN_MAP', DEFAULTS["map"])
     domain_rand = bool(os.getenv('DUCKIETOWN_DOMAIN_RAND', DEFAULTS["domain_rand"]))
-    max_steps = os.getenv('DUCKIETOWN_MAX_STEPS', DEFAULTS["max_steps"])
+    max_steps = int(os.getenv('DUCKIETOWN_MAX_STEPS', DEFAULTS["max_steps"]))
 
     # if a challenge is set, it overrides the map selection
 


### PR DESCRIPTION
If we call the launcher with DUCKIETOWN_MAX_STEPS as a subprocess, the values that come from the environment can only be strings. We need to convert the value that comes from `int` to `string`.
