### PR TITLE
adding to wheel velocity wrapper

### DIFF
--- a/gym_duckietown/wrappers.py
+++ b/gym_duckietown/wrappers.py
@@ -29,6 +29,66 @@ class DiscreteWrapper(gym.ActionWrapper):
         return np.array(vels)
 
 
+class SteeringToWheelVelWrapper(gym.ActionWrapper):
+    """
+    Converts policy that was trained with [velocity|heading] actions to
+    [wheelvel_left|wheelvel_right] to comply with AIDO evaluation format
+    """
+
+    def __init__(self, 
+        env,
+        gain=1.0,
+        trim=0.0,
+        radius=0.0318,
+        k=27.0,
+        limit=1.0
+    ):
+        gym.ActionWrapper.__init__(self, env)
+
+        # Should be adjusted so that the effective speed of the robot is 0.2 m/s
+        self.gain = gain
+
+        # Directional trim adjustment
+        self.trim = trim
+
+        # Wheel radius
+        self.radius = radius
+
+        # Motor constant
+        self.k = k
+
+        # Wheel velocity limit
+        self.limit = limit
+
+
+    def action(self, action):
+        vel, angle = action
+
+        # Distance between the wheels
+        baseline = self.unwrapped.wheel_dist
+
+        # assuming same motor constants k for both motors
+        k_r = self.k
+        k_l = self.k
+
+        # adjusting k by gain and trim
+        k_r_inv = (self.gain + self.trim) / k_r
+        k_l_inv = (self.gain - self.trim) / k_l
+
+        omega_r = (vel + 0.5 * angle * baseline) / self.radius
+        omega_l = (vel - 0.5 * angle * baseline) / self.radius
+
+        # conversion from motor rotation rate to duty cycle
+        u_r = omega_r * k_r_inv
+        u_l = omega_l * k_l_inv
+
+        # limiting output to limit, which is 1.0 for the duckiebot
+        u_r_limited = max(min(u_r, self.limit), -self.limit)
+        u_l_limited = max(min(u_l, self.limit), -self.limit)
+
+        vels = np.array([u_l_limited, u_r_limited])
+        return vels
+
 class PyTorchObsWrapper(gym.ObservationWrapper):
     """
     Transpose the observation image tensors for PyTorch


### PR DESCRIPTION
Converts policy that was trained with `[velocity|heading]` actions `[wheelvel_left|wheelvel_right]` to comply with AIDO evaluation format

Addresses #104 