### PR TITLE
Fix bug : compute_reward parameter 'self.robot_speed' to 'self.speed'

### DIFF
--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -1363,7 +1363,7 @@ class Simulator(gym.Env):
             done_code = 'max-steps-reached'
         else:
             done = False
-            reward = self.compute_reward(self.cur_pos, self.cur_angle, self.robot_speed)
+            reward = self.compute_reward(self.cur_pos, self.cur_angle, self.speed)
             msg = ''
             done_code = 'in-progress'
         return DoneRewardInfo(done=done, done_why=msg, reward=reward, done_code=done_code)


### PR DESCRIPTION
self.robot_speed is a constant value set to 1.2
The reward was computed without taking the actual speed into consideration.
The argument for the parameter "speed" of function "compute_reward" should be self.speed.