### PR TITLE
Fix bug when OpenGL < 3.2

### DIFF
--- a/gym_duckietown/graphics.py
+++ b/gym_duckietown/graphics.py
@@ -93,6 +93,7 @@ def create_frame_buffers(width, height, num_samples):
         if not gl.gl_info.have_version(major=3, minor=2):
             raise Exception('OpenGL version 3.2+ required for \
                             GL_TEXTURE_2D_MULTISAMPLE')
+
         # Create a multisampled texture to render into
         fbTex = gl.GLuint(0)
         gl.glGenTextures( 1, byref(fbTex))

--- a/gym_duckietown/graphics.py
+++ b/gym_duckietown/graphics.py
@@ -90,6 +90,9 @@ def create_frame_buffers(width, height, num_samples):
     # (Intel GPU drivers on macbooks in particular) do not
     # support multisampling on frame buffer objects
     try:
+        if not gl.gl_info.have_version(major=3, minor=2):
+            raise Exception('OpenGL version 3.2+ required for \
+                            GL_TEXTURE_2D_MULTISAMPLE')
         # Create a multisampled texture to render into
         fbTex = gl.GLuint(0)
         gl.glGenTextures( 1, byref(fbTex))


### PR DESCRIPTION
I was hitting the following assertion because my computer is old and my OpenGL version is 3.0 (version 3.2 is [required](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBindTexture.xhtml) for `GL_TEXTURE_2D_MULTISAMPLE`). 

>Traceback (most recent call last):
...
  File "/home/plafer/code/dt-env-developer/aido/challenge-aido_LF-baseline-RL-sim-pytorch/src/gym-duckietown/gym_duckietown/graphics.py", line 157, in create_frame_buffers
    assert res == gl.GL_FRAMEBUFFER_COMPLETE
AssertionError

My change fixes the bug. I didn't want to touch the current `try/except` because I assume that it's there because on some environments an exception was thrown. I'm not sure what causes this exception to be thrown in these environments, but if it's dependent on `pyglet.options['debug_gl'] == True`, then it won't work whenever [Python is run with the -O option](https://pyglet.readthedocs.io/en/pyglet-1.3-maintenance/programming_guide/options.html).

PR is against aido2 branch because that's still what the docs have users pull, but if this branch is no longer maintained, then I can retarget to master.