### PR TITLE
Collect environment and action metrics during reinforcement learning

### DIFF
--- a/learning/reinforcement/pytorch/enjoy_reinforcement.py
+++ b/learning/reinforcement/pytorch/enjoy_reinforcement.py
@@ -9,10 +9,10 @@ import numpy as np
 from reinforcement.pytorch.ddpg import DDPG
 from utils.env import launch_env
 from utils.wrappers import NormalizeWrapper, ImgWrapper, \
-    DtRewardWrapper, ActionWrapper, ResizeWrapper
+    DtRewardWrapper, ActionWrapper, ResizeWrapper, MetricsWrapper
 
 
-def _enjoy():          
+def _enjoy():
     # Launch the env with our helper function
     env = launch_env()
     print("Initialized environment")
@@ -21,8 +21,9 @@ def _enjoy():
     env = ResizeWrapper(env)
     env = NormalizeWrapper(env)
     env = ImgWrapper(env) # to make the images from 160x120x3 into 3x160x120
-    env = ActionWrapper(env)
     env = DtRewardWrapper(env)
+    env = MetricsWrapper(env)
+    env = ActionWrapper(env)
     print("Initialized Wrappers")
 
     state_dim = env.observation_space.shape
@@ -43,7 +44,7 @@ def _enjoy():
             obs, reward, done, _ = env.step(action)
             env.render()
         done = False
-        obs = env.reset()        
+        obs = env.reset()
 
 if __name__ == '__main__':
     _enjoy()

--- a/learning/utils/metrics.py
+++ b/learning/utils/metrics.py
@@ -1,0 +1,20 @@
+import csv
+from os import path
+from datetime import datetime
+
+class Metrics:
+    def __init__(self):
+        self.filename = 'metrics-' + str(datetime.now()).replace(' ', '-').replace(':', '-') + '.csv'
+        with open(self.filename, mode='w') as metrics_file:
+            self.metrics_writer = csv.writer(metrics_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            self.metrics_writer.writerow(['datetime', 'step', 'x', 'y', 'angle', 'speed', 'steering',
+                                          'center_dist', 'center_angle', 'reward', 'total_reward'])
+
+    def record(self, step, x, y, angle, speed, steering, center_dist, center_angle, reward, total_reward):
+        now = str(datetime.now())
+        #print({now, step, speed, steering, center_dist, center_angle, reward, total_reward})
+
+        with open(self.filename, mode='a') as metrics_file:
+            self.metrics_writer = csv.writer(metrics_file, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            self.metrics_writer.writerow([now, step, x, y, angle, speed, steering,
+                                          center_dist, center_angle, reward, total_reward])


### PR DESCRIPTION
Creates a metrics csv file that allows train or enjoy progress to be easily explored, graphed and debugged.

For example here is a scatter plot of x and y that demonstrates the default training settings fail to train the bot and instead induce either wiggling in place or spinning in place:
![image](https://user-images.githubusercontent.com/942679/68548764-821f9980-03be-11ea-88c6-af0d7c69ce39.png)
The above generated with
```
data = pd.read_csv("metrics-training.csv") 
sns.scatterplot(x="x", y="y", hue='step', data=data)
```

A sample excerpt from the metrics csv file for training:
```
datetime,step,x,y,angle,speed,steering,center_dist,center_angle,reward,total_reward
2019-11-10 13:24:51.595017,1,2.643872463995367,2.9012396542240886,4.8690985603846855,0.3757399320602417,0.46001503,-0.13055107592213924,0.035870341709401815,3.19559684058306,3.19559684058306
2019-11-10 13:24:51.624950,2,2.6461244240452295,2.9163726845417557,4.8511330472675125,0.405402946472168,0.3595909,-0.12986506835069456,0.0538358548265737,3.1596744597449034,6.3552713003279635
2019-11-10 13:24:51.643253,3,2.646838734203294,2.9244335382732203,4.750412590849644,0.33081514835357667,0.073977984,-0.12902339261159254,0.15455631124444458,2.9496454310411275,9.30491673136909
```

Wrappers modifying observations or rewards should be below the MetricsWrapper.  Wrappers modifying actions should be above the MetricsWrapper.  Therefore the ActionWrapper was moved above the MetricsWrapper to allow the MetricsWrapper to see the modified Actions.  

I'm new to python and duckietown and new to pull requests to open source projects. So your guidance and feedback are much appreciated.