### PR TITLE
A suggested solution to fix collision issues with dynamic duckiebots

### DIFF
--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -748,9 +748,9 @@ class Simulator(gym.Env):
             possible_tiles = find_candidate_tiles(obj.obj_corners, self.road_tile_size)
 
             # If the object intersects with a drivable tile
-            if not static or (static and kind != "trafficlight" and self._collidable_object(
+            if static and kind != "trafficlight" and self._collidable_object(
                     obj.obj_corners, obj.obj_norm, possible_tiles
-            )):
+            ):
                 self.collidable_centers.append(pos)
                 self.collidable_corners.append(obj.obj_corners.T)
                 self.collidable_norms.append(obj.obj_norm)
@@ -1199,24 +1199,19 @@ class Simulator(gym.Env):
         """
         Tensor-based OBB Collision detection
         """
-
-        # If there are no objects to collide against, stop
-        if len(self.collidable_corners) == 0:
-            return False
-
         # Generate the norms corresponding to each face of BB
         agent_norm = generate_norm(agent_corners)
 
-        # Check collisions with static objects
-        collision = intersects(
-                agent_corners,
-                self.collidable_corners,
-                agent_norm,
-                self.collidable_norms
-        )
-
-        if collision:
-            return True
+        # Check collisions with Static Objects
+        if len(self.collidable_corners) > 0:
+            collision = intersects(
+                    agent_corners,
+                    self.collidable_corners,
+                    agent_norm,
+                    self.collidable_norms
+            )
+            if collision:
+                return True
 
         # Check collisions with Dynamic Objects
         for obj in self.objects:


### PR DESCRIPTION
Fixes #216. Also, if there are no static obstacles, therefore `len(self.collidable_corners) == 0`, collision with dynamic obstacles is still checked.