### PR TITLE
Added a line 305 and modified 306 to look for the directory of simula…

### DIFF
--- a/gym_duckietown/simulator.py
+++ b/gym_duckietown/simulator.py
@@ -302,7 +302,8 @@ class Simulator(gym.Env):
 
         if self.randomize_maps_on_reset:
             import os
-            self.map_names = os.listdir('maps')
+            dir_path = os.path.dirname(os.path.realpath(__file__))
+            self.map_names = os.listdir(dir_path + '/maps')
             self.map_names = [mapfile.replace('.yaml', '') for mapfile in self.map_names]
 
         # Initialize the state


### PR DESCRIPTION
…tor.py and then use that as a reference for looking up /maps/. The previous selection would fail whenever gym-duckietow/gym_duckietown/ was not in the python path, such as when using gym_duckietown as a submodule of another project