### PR TITLE
Add python3.7 support via typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 
 duckietown-world-daffy
 pipdeptree
+typing-extensions

--- a/src/gym_duckietown/objmesh.py
+++ b/src/gym_duckietown/objmesh.py
@@ -1,6 +1,13 @@
 # coding=utf-8
 import os
-from typing import cast, Dict, TypedDict
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+from typing import cast, Dict
 
 import numpy as np
 import pyglet

--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -3,7 +3,15 @@ import os
 from collections import namedtuple
 from ctypes import POINTER
 from dataclasses import dataclass
-from typing import Any, cast, Dict, List, NewType, Optional, Sequence, Tuple, TypedDict, Union
+
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import TypedDict
+else:
+    from typing_extensions import TypedDict
+
+from typing import Any, cast, Dict, List, NewType, Optional, Sequence, Tuple, Union
 
 import geometry
 import geometry as g


### PR DESCRIPTION
Along with https://github.com/duckietown/duckietown-world/pull/53, this change fixes gym-duckietown to be compatible with Python3.7. Most importantly this unblocks users from training on Colab.