### PR TITLE
Fixes gym loading using gym.register

### DIFF
--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -768,6 +768,11 @@ class Simulator(gym.Env):
         """
 
         # Store the map name
+        if os.path.exists(map_name):
+            # if env is loaded using gym's register function, we need to extract the map name from the complete url
+            map_name = os.path.basename(map_name)
+            assert map_name.endswith(".yaml")
+            map_name = ".".join(map_name.split(".")[:-1])
         self.map_name = map_name
 
         # Get the full map file path

--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -768,7 +768,7 @@ class Simulator(gym.Env):
         """
 
         # Store the map name
-        if os.path.exists(map_name):
+        if os.path.exists(map_name) and os.path.isfile(map_name):
             # if env is loaded using gym's register function, we need to extract the map name from the complete url
             map_name = os.path.basename(map_name)
             assert map_name.endswith(".yaml")


### PR DESCRIPTION
Expected behaviour: `gym.make(env_id)` loads the appropriate duckietown env.

Actual behaviour: 

```
  File "/home/charlie/Desktop/diaynckietow/main.py", line 197, in <lambda>
    (lambda: make_env(idx, test))
  File "/home/charlie/Desktop/diaynckietow/main.py", line 179, in make_env
    atari_wrappers.make_atari(args.env, max_frames=args.max_frames),
  File "/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/pfrl-0.3.0-py3.9.egg/pfrl/wrappers/atari_wrappers.py", line 287, in make_atari
    env = gym.make(env_id)
  File "/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/gym/envs/registration.py", line 184, in make
    return registry.make(id, **kwargs)
  File "/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/gym/envs/registration.py", line 106, in make
    env = spec.make(**kwargs)
  File "/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/gym/envs/registration.py", line 76, in make
    env = cls(**_kwargs)
  File "/home/charlie/Desktop/diaynckietow/gym-duckietown/src/gym_duckietown/envs/duckietown_env.py", line 16, in __init__
    Simulator.__init__(self, **kwargs)
  File "/home/charlie/Desktop/diaynckietow/gym-duckietown/src/gym_duckietown/simulator.py", line 349, in __init__
    self._load_map(map_name)
  File "/home/charlie/Desktop/diaynckietow/gym-duckietown/src/gym_duckietown/simulator.py", line 780, in _load_map
    self.map_file_path = get_resource_path(f"{map_name}.yaml")
  File "/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/duckietown_world/resources.py", line 82, in get_resource_path
    raise ZKeyError(msg, known=sorted(res2), res1=sorted(res1))
zuper_commons.types.exceptions.ZKeyError: Could not find resource '/home/charlie/Desktop/diaynckietow/venv/lib/python3.9/site-packages/duckietown_world/data/gd1/maps/udem1.yaml.yaml'.
```

Reason: the `map_name` received by the simulator is already the full path (hence why there are two "yaml" extensions at the botton of the above log: the simulator tries to look for `map_name.yaml`.

Fix: extract the map name from map_name in the case that map_name points to a file.