### PR TITLE
Fix randint

### DIFF
--- a/src/gym_duckietown/randomization/randomizer.py
+++ b/src/gym_duckietown/randomization/randomizer.py
@@ -52,7 +52,7 @@ class Randomizer:
                     except:
                         raise IndexError("Please check your randomization definition for: {}".format(k))
 
-                    setting = rng.randint(low=low, high=high, size=size)
+                    setting = rng.integers(low=low, high=high, size=size)
 
                 elif randomization_definition["type"] == "uniform":
                     try:

--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -651,7 +651,7 @@ class Simulator(gym.Env):
 
             # Randomize whether the object is visible or not
             if obj.optional and self.domain_rand:
-                obj.visible = self.np_random.randint(0, 2) == 0
+                obj.visible = self.np_random.integers(0, 2) == 0
             else:
                 obj.visible = True
 
@@ -672,7 +672,7 @@ class Simulator(gym.Env):
                 if not self.drivable_tiles:
                     msg = "There are no drivable tiles. Use start_tile or self.user_tile_start"
                     raise Exception(msg)
-                tile_idx = self.np_random.randint(0, len(self.drivable_tiles))
+                tile_idx = self.np_random.integers(0, len(self.drivable_tiles))
                 tile = self.drivable_tiles[tile_idx]
 
         # If the map specifies a starting pose


### PR DESCRIPTION
```
'numpy.random._generator.Generator' object has no attribute 'randint'
```

Problem occurred when running usr/bin/launch-data-collection.sh in mooc-exercises/object-detection homework

From numpy randint page: New code should use the integers method of a default_rng() instance instead

https://numpy.org/doc/stable/reference/random/generated/numpy.random.randint.html