### PR TITLE
Change manual.py to behave (presumably) as expected.

### DIFF
--- a/manual_control.py
+++ b/manual_control.py
@@ -32,6 +32,8 @@ parser.add_argument("--seed", default=1, type=int, help="seed")
 args = parser.parse_args()
 
 if args.env_name and args.env_name.find("Duckietown") != -1:
+    env = gym.make(args.env_name)
+else:
     env = DuckietownEnv(
         seed=args.seed,
         map_name=args.map_name,
@@ -43,8 +45,6 @@ if args.env_name and args.env_name.find("Duckietown") != -1:
         camera_rand=args.camera_rand,
         dynamics_rand=args.dynamics_rand,
     )
-else:
-    env = gym.make(args.env_name)
 
 env.reset()
 env.render()


### PR DESCRIPTION
With this update, when --env_name or --map_name is specified as an argument in manual.py, it can now run in the specified environment.
Related to #195

**Change**
In the environment building section, environments were originally built with DuckietownEnv if env_name contained Duckietown, and with gym_make if env_name did not contain Duckietown. It has been changed to build the environment with gym_make if env_name contains Duckietown and with DuckietownEnv if env_name does not contain Duckietown.