### PR TITLE
Use numpy.random.Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ bin
 trained_models
 dist
 requirements.resolved
+.venv
+build

--- a/manual_control.py
+++ b/manual_control.py
@@ -32,6 +32,8 @@ parser.add_argument("--seed", default=1, type=int, help="seed")
 args = parser.parse_args()
 
 if args.env_name and args.env_name.find("Duckietown") != -1:
+    env = gym.make(args.env_name)
+else:
     env = DuckietownEnv(
         seed=args.seed,
         map_name=args.map_name,
@@ -43,8 +45,6 @@ if args.env_name and args.env_name.find("Duckietown") != -1:
         camera_rand=args.camera_rand,
         dynamics_rand=args.dynamics_rand,
     )
-else:
-    env = gym.make(args.env_name)
 
 env.reset()
 env.render()

--- a/manual_control.py
+++ b/manual_control.py
@@ -31,9 +31,11 @@ parser.add_argument("--frame-skip", default=1, type=int, help="number of frames 
 parser.add_argument("--seed", default=1, type=int, help="seed")
 args = parser.parse_args()
 
-if args.env_name and args.env_name.find("Duckietown") != -1:
+if args.env_name and (args.env_name == 'MultiMap-v0' or args.env_name.find("Duckietown") != -1):
+    print(f'Using the environment: {args.env_name}')
     env = gym.make(args.env_name)
 else:
+    print(f'Using the map: {args.map_name}')
     env = DuckietownEnv(
         seed=args.seed,
         map_name=args.map_name,

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,9 @@ version = get_version(filename="src/gym_duckietown/__init__.py")
 line = "daffy"
 
 install_requires = [
-    "gym>=0.17.1",
-    "numpy>=1.10.0,<=1.20.0",
-    "pyglet",
-    # 'pyglet',
+    "gym>=0.17.1,<=0.23.1",
+    "numpy>=1.17.0,<1.24.0",
+    "pyglet==1.5.*",
     "pyzmq>=16.0.0",
     "opencv-python>=3.4",
     "PyYAML>=3.11",

--- a/src/gym_duckietown/envs/multimap_env.py
+++ b/src/gym_duckietown/envs/multimap_env.py
@@ -10,14 +10,13 @@ class MultiMapEnv(gym.Env):
     multi-taks learning
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, map_names=["straight_road", "4way", "udem1", "small_loop", "small_loop_cw", "zigzag_dists", "loop_obstacles", "loop_pedestrians"], **kwargs):
         self.env_list = []
 
         self.window = None
-        map_names = ["loop_only_duckies", "small_loop_only_duckies"]
         # Try loading each of the available map files
         for map_name in map_names:
-            env = DuckietownEnv(map_name=map_name, **kwargs)
+            env = gym.make(f'Duckietown-{map_name}-v0', **kwargs)
 
             self.action_space = env.action_space
             self.observation_space = env.observation_space
@@ -48,6 +47,11 @@ class MultiMapEnv(gym.Env):
         env = self.env_list[self.cur_env_idx]
         return env.reset()
 
+    @property
+    def frame_rate(self):
+        # Return the frame rate of the current environment
+        return self.env_list[self.cur_env_idx].frame_rate
+
     def step(self, action):
         env = self.env_list[self.cur_env_idx]
 
@@ -69,11 +73,11 @@ class MultiMapEnv(gym.Env):
 
         # Make all environments use the same rendering window
         if self.window is None:
-            ret = env.render(mode, close)
+            ret = env.render(mode=mode, close=close)
             self.window = env.window
         else:
             env.window = self.window
-            ret = env.render(mode, close)
+            ret = env.render(mode=mode, close=close)
 
         return ret
 

--- a/src/gym_duckietown/randomization/randomizer.py
+++ b/src/gym_duckietown/randomization/randomizer.py
@@ -1,6 +1,6 @@
 import json
 
-from numpy.random.mtrand import RandomState
+from numpy.random import Generator
 
 from .. import logger
 from ..utils import get_file_path
@@ -33,11 +33,10 @@ class Randomizer:
         # Sorted list to generate parameters in the same order
         self.keys = sorted(set(list(self.randomization_config.keys()) + list(self.default_config.keys())))
 
-    def randomize(self, rng: RandomState) -> dict:
+    def randomize(self, rng: Generator) -> dict:
         """Returns a dictionary of randomized parameters, with key: parameter name and value: randomized
         value
         """
-        # assert isinstance(rng, RandomState)
         randomization_settings = {}
         # from numpy.random import Generator
         # from numpy import __version__ as np_version
@@ -56,10 +55,7 @@ class Randomizer:
                     except:
                         raise IndexError("Please check your randomization definition for: {}".format(k))
 
-                    try:
-                        setting = rng.randint(low=low, high=high, size=size)
-                    except:
-                        setting = rng.integers(low=low, high=high, size=size)
+                    setting = rng.integers(low=low, high=high, size=size)
 
                 elif randomization_definition["type"] == "uniform":
                     try:

--- a/src/gym_duckietown/simulator.py
+++ b/src/gym_duckietown/simulator.py
@@ -23,7 +23,7 @@ import yaml
 from geometry import SE2value
 from gym import spaces
 from gym.utils import seeding
-from numpy.random.mtrand import RandomState
+from numpy.random import Generator, default_rng
 from pyglet import gl, image, window
 
 from duckietown_world import (
@@ -201,7 +201,7 @@ class Simulator(gym.Env):
     grid_height: int
     step_count: int
     timestamp: float
-    np_random: RandomState
+    np_random: Generator
     grid: List[TileDict]
 
     def __init__(
@@ -1041,7 +1041,7 @@ class Simulator(gym.Env):
         pass
 
     def seed(self, seed=None):
-        self.np_random, _ = seeding.np_random(seed)
+        self.np_random = default_rng(seed)
         return [seed]
 
     def _set_tile(self, i: int, j: int, tile: TileDict) -> None:


### PR DESCRIPTION
This is an update to use `numpy.random.Generator` instead of `numpy.random.mtrand.RandomState` since it is deprecated. The required library versions are also updated.